### PR TITLE
Fix PyPI publishing configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,3 @@ packages = ["google_alert"]
 
 [tool.hatch.build.sources]
 "." = "google_alert"
-
-[tool.uv.publish]
-repository = "pypi"


### PR DESCRIPTION
This PR fixes the PyPI publishing issues:

- Removes invalid [tool.uv.publish] section that was causing TOML parse error
- Fixes the pyproject.toml configuration for proper uv publishing
- Prepares for trusted publishing once PyPI project is created

After this PR is merged and the PyPI project is created with the correct trusted publisher configuration, we can create a new release to publish to PyPI.